### PR TITLE
meson: Add missing semicolumn in libwavpack.map

### DIFF
--- a/libwavpack.map
+++ b/libwavpack.map
@@ -73,5 +73,6 @@
   WavpackUpdateNumSamples;
   WavpackVerifySingleBlock;
   WavpackWriteTag;
- local: *
+ local:
+  *;
 };


### PR DESCRIPTION
This fix build issues with recent versions of GNU LD.

/cc @dragonmux